### PR TITLE
Fix `MCX_SRC_MSOT_ACUITY_ECHO` and `MCX_SRC_INVISION` indices

### DIFF
--- a/src/mcx_const.h
+++ b/src/mcx_const.h
@@ -93,9 +93,9 @@
 #define MCX_SRC_PENCILARRAY 14 /**<  a rectangular array of pencil beams */
 #define MCX_SRC_PATTERN3D  15  /**<  a 3D pattern source, starting from srcpos, srcparam1.{x,y,z} define the x/y/z dimensions */
 #define MCX_SRC_HYPERBOLOID_GAUSSIAN 16 /**<  Gaussian-beam with spot focus, scrparam1.{x,y,z} define beam waist, distance from source to focus, rayleigh range */
-#define MCX_SRC_MSOT_ACUITY_ECHO  17  /**<  a source that approximates the MSOT Acuity Echo illumination geometry*/
-#define MCX_SRC_INVISION  18  /**<  a source that approximates the MSOT invision tf-256 illumination geometry*/
 #define MCX_SRC_RING       17 /**<  ring/ring-sector source, scrparam1.{x,y} defines the outer/inner radius, srcparam1.{z,w} defines start/end angle*/
+#define MCX_SRC_MSOT_ACUITY_ECHO  18  /**<  a source that approximates the MSOT Acuity Echo illumination geometry*/
+#define MCX_SRC_INVISION  19  /**<  a source that approximates the MSOT invision tf-256 illumination geometry*/
 
 #define SAVE_DETID(a)         ((a)    & 0x1)   /**<  mask to save detector ID*/
 #define SAVE_NSCAT(a)         ((a)>>1 & 0x1)   /**<  output partial scattering counts */


### PR DESCRIPTION
- ensure they match their location in the `srctypeid` array from src/mcx_utils.c
- also resolves compile error `src/mcx_core.cu(1404): error: case label value has already appeared in this switch`